### PR TITLE
chore: request casting and wp encode use

### DIFF
--- a/src/Helpers/JSON.php
+++ b/src/Helpers/JSON.php
@@ -6,7 +6,7 @@ final class JSON
 {
     public static function encode($data, $options = 0, $depth = 512)
     {
-        return json_encode($data, $options, $depth);
+        return wp_json_encode($data, $options, $depth);
     }
 
     public static function maybeEncode($data, $options = 0, $depth = 512)

--- a/src/Http/Request/Request.php
+++ b/src/Http/Request/Request.php
@@ -239,7 +239,7 @@ class Request extends Validator implements ArrayAccess, JsonSerializable
                 strpos($this->contentType(), 'form-data')                === false
                 && strpos($this->contentType(), 'x-www-form-urlencoded') === false
             ) {
-                $this->_body = JSON::maybeDecode(file_get_contents('php://input'));
+                $this->_body = JSON::maybeDecode(file_get_contents('php://input'), true);
             }
 
             $this->_body = (array) $this->_body + (array) $_POST;


### PR DESCRIPTION
chore: request value decode object to array

chore: use the wp function to encode JSON