### PR TITLE
fix(http): restrict unsafe requests by host

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,17 @@ $body   = $client->request('https://api.example.com/hooks', 'POST', ['event' => 
 $code   = $client->getResponseCode();
 ```
 
-Safe by default (`wp_safe_remote_request`); call `$client->allowUnsafeUrls()` to
-reach internal hosts.
+Safe by default (`wp_safe_remote_request`). To reach known internal hosts, an
+administrator must explicitly enable unsafe URLs and allowlist each exact trusted
+endpoint host:
+
+```php
+$client = (new HttpClient())
+    ->allowUnsafeUrls(true, ['10.0.0.20', 'internal-api.example']);
+```
+
+Only administrator-configured trusted endpoints belong in this allowlist; never
+derive hosts from arbitrary request values. Unsafe requests never follow redirects.
 
 ### 7. Hooks, shortcodes, lifecycle
 
@@ -177,14 +186,22 @@ front-end page URLs (via rewrite rules) to routes.
   ```
 
 - `HttpClient` uses `wp_safe_remote_request()` by default. Internal or otherwise
-  unsafe URLs require an explicit opt-in:
+  unsafe URLs require an explicit, administrator-configured exact-host allowlist:
 
   ```php
-  $client->allowUnsafeUrls();
+  $client->allowUnsafeUrls(true, ['10.0.0.20', 'internal-api.example']);
   ```
+
+  Do not allowlist hosts supplied by arbitrary requests. Unsafe requests do not
+  follow redirects.
 
 ## Upgrade notes
 
+- `HttpClient::allowUnsafeUrls()` remains a valid call, but calling it without an
+  explicit host allowlist now intentionally fails closed. Unsafe requests return
+  a `WP_Error` with the `unsafe_url_not_allowed` code instead of reaching the
+  transport. Configure exact, trusted hosts with
+  `allowUnsafeUrls(true, ['internal-api.example'])`.
 - `Response::headers()` now requires an array and validates every entry through
   `Response::header()`; invalid header names, values containing CR/LF/NUL, and
   non-scalar values throw `InvalidArgumentException` instead of being stored

--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ $client = (new HttpClient())
     ->allowUnsafeUrls(true, ['10.0.0.20', 'internal-api.example']);
 ```
 
+Authorization is host-only: URLs must use HTTP or HTTPS, but any port and path
+on an allowlisted host remain reachable. Validate untrusted URL components
+separately.
+
 Only administrator-configured trusted endpoints belong in this allowlist; never
 derive hosts from arbitrary request values. Unsafe requests never follow redirects.
 

--- a/src/Http/Client/HttpClient.php
+++ b/src/Http/Client/HttpClient.php
@@ -249,6 +249,8 @@ final class HttpClient
 
     public function request($url, $type, $data, $headers = null, $options = null)
     {
+        $this->_responseHeaders = [];
+
         $defaultOptions = [
             'method'  => strtoupper($type),
             'headers' => empty($headers) ? $this->getHeaders() : $headers,

--- a/src/Http/Client/HttpClient.php
+++ b/src/Http/Client/HttpClient.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use BitApps\WPKit\Helpers\JSON;
 
 use InvalidArgumentException;
+use WP_Error;
 
 final class HttpClient
 {
@@ -257,9 +258,18 @@ final class HttpClient
         ];
         $options = wp_parse_args($options, $defaultOptions);
 
-        $requestResponse = $this->_allowUnsafeUrls
-            ? wp_remote_request($url, $options)
-            : wp_safe_remote_request($url, $options);
+        if ($this->_allowUnsafeUrls) {
+            if (!$this->isUnsafeUrlAllowed($url)) {
+                $this->_requestResponse = new WP_Error('unsafe_url_not_allowed', 'Unsafe URL host is not allowlisted.');
+
+                return $this->_requestResponse;
+            }
+
+            $options['redirection'] = 0;
+            $requestResponse        = wp_remote_request($url, $options);
+        } else {
+            $requestResponse = wp_safe_remote_request($url, $options);
+        }
 
         $this->_requestResponse = $requestResponse;
 
@@ -458,5 +468,20 @@ final class HttpClient
         }
 
         return $host;
+    }
+
+    private function isUnsafeUrlAllowed($url): bool
+    {
+        $urlParts = wp_parse_url($url);
+        if (!\is_array($urlParts) || !isset($urlParts['scheme'], $urlParts['host'])) {
+            return false;
+        }
+
+        $scheme = strtolower($urlParts['scheme']);
+        $host   = $this->normalizeHost($urlParts['host']);
+
+        return \in_array($scheme, ['http', 'https'], true)
+            && $host !== ''
+            && \in_array($host, $this->_allowedUnsafeHosts, true);
     }
 }

--- a/src/Http/Client/HttpClient.php
+++ b/src/Http/Client/HttpClient.php
@@ -37,6 +37,8 @@ final class HttpClient
 
     private bool $_allowUnsafeUrls = false;
 
+    private array $_allowedUnsafeHosts = [];
+
     /**
      * Undocumented function.
      *
@@ -127,9 +129,25 @@ final class HttpClient
         return $this;
     }
 
-    public function allowUnsafeUrls($allow = true): self
+    public function allowUnsafeUrls($allow = true, array $allowedHosts = []): self
     {
         $this->_allowUnsafeUrls = (bool) $allow;
+        $this->setAllowedUnsafeHosts($allowedHosts);
+
+        return $this;
+    }
+
+    public function getAllowedUnsafeHosts(): array
+    {
+        return $this->_allowedUnsafeHosts;
+    }
+
+    public function setAllowedUnsafeHosts(array $hosts): self
+    {
+        $this->_allowedUnsafeHosts = array_values(array_unique(array_filter(array_map(
+            [$this, 'normalizeHost'],
+            $hosts,
+        ))));
 
         return $this;
     }
@@ -298,9 +316,10 @@ final class HttpClient
             $this->setMultipart($config['multipart']);
         }
 
-        if (isset($config['allow_unsafe_urls'])) {
-            $this->allowUnsafeUrls($config['allow_unsafe_urls']);
-        }
+        $this->allowUnsafeUrls(
+            $config['allow_unsafe_urls']    ?? false,
+            $config['allowed_unsafe_hosts'] ?? [],
+        );
     }
 
     public function setJson($data): self
@@ -405,5 +424,39 @@ final class HttpClient
         $multipart .= '--' . $this->getBoundary() . '--';
 
         return $multipart;
+    }
+
+    private function normalizeHost($host): string
+    {
+        if (!\is_string($host)) {
+            return '';
+        }
+
+        $host = trim($host);
+        if ($host === '') {
+            return '';
+        }
+
+        if (str_starts_with($host, '[') && str_ends_with($host, ']')) {
+            $host = substr($host, 1, -1);
+            if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false) {
+                return '';
+            }
+        }
+
+        if ($host === '' || filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return strtolower($host);
+        }
+
+        $host = strtolower($host);
+        if (str_ends_with($host, '.')) {
+            $host = substr($host, 0, -1);
+        }
+
+        if ($host === '' || filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false) {
+            return '';
+        }
+
+        return $host;
     }
 }

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -34,6 +34,38 @@ final class HttpClientTest extends TestCase
         assertSameValue(false, $response->safe, 'unsafe transport response was not returned');
     }
 
+    public function testHTTPClientUnsafeUrlAllowlistIsNormalizedAndReplaced(): void
+    {
+        $client = new HttpClient();
+
+        assertSameValue(
+            $client,
+            $client->allowUnsafeUrls(true, ['  INTERNAL.example.  ', '[::1]', '127.0.0.1', 'internal.example']),
+            'unsafe URL configuration stopped being fluent',
+        );
+        assertSameValue(
+            ['internal.example', '::1', '127.0.0.1'],
+            $client->getAllowedUnsafeHosts(),
+            'unsafe host allowlist was not normalized',
+        );
+
+        $client->allowUnsafeUrls(true);
+
+        assertSameValue([], $client->getAllowedUnsafeHosts(), 'empty unsafe host allowlist did not replace prior entries');
+    }
+
+    public function testHTTPClientUnsafeHostAllowlistRejectsInvalidValues(): void
+    {
+        $client = new HttpClient();
+
+        assertSameValue(
+            $client,
+            $client->setAllowedUnsafeHosts(['', ' https://internal.example ', 'host/path', '[bracketed.example]', [], true, 123, 'valid.example']),
+            'unsafe host allowlist setter stopped being fluent',
+        );
+        assertSameValue(['valid.example'], $client->getAllowedUnsafeHosts(), 'invalid unsafe host entries were retained');
+    }
+
     public function testHTTPClientWordPressErrorsAreReturnedUnchanged(): void
     {
         $client   = new HttpClient();
@@ -45,14 +77,15 @@ final class HttpClientTest extends TestCase
     public function testHTTPClientConstructorAppliesSupportedDefaults(): void
     {
         $client = new HttpClient([
-            'base_uri'          => 'https://example.com/',
-            'content_type'      => 'text/plain',
-            'headers'           => ['X-Test' => 'value'],
-            'body'              => ['body' => 'value'],
-            'form_params'       => ['form' => 'value'],
-            'json'              => ['json' => 'value'],
-            'multipart'         => [['name' => 'part', 'contents' => 'value']],
-            'allow_unsafe_urls' => true,
+            'base_uri'             => 'https://example.com/',
+            'content_type'         => 'text/plain',
+            'headers'              => ['X-Test' => 'value'],
+            'body'                 => ['body' => 'value'],
+            'form_params'          => ['form' => 'value'],
+            'json'                 => ['json' => 'value'],
+            'multipart'            => [['name' => 'part', 'contents' => 'value']],
+            'allow_unsafe_urls'    => true,
+            'allowed_unsafe_hosts' => ['internal.example'],
         ]);
 
         assertSameValue('https://example.com/', $client->getBaseUri(), 'base URI default was not applied');
@@ -65,6 +98,7 @@ final class HttpClientTest extends TestCase
             $client->getMultipart(),
             'multipart default was not applied',
         );
+        assertSameValue(['internal.example'], $client->getAllowedUnsafeHosts(), 'unsafe host allowlist default was not applied');
     }
 
     public function testHTTPClientFluentConfigurationRetainsRequestValues(): void

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -35,6 +35,28 @@ final class HttpClientTest extends TestCase
         assertSameValue(['safe' => 0, 'unsafe' => 0], WpKitTestState::$httpCalls, 'rejected URL reached a transport');
     }
 
+    public function testHTTPClientAuthorizationRejectionClearsHeadersFromAPriorResponse(): void
+    {
+        $client = new HttpClient();
+        $client->request('https://example.com', 'GET', []);
+
+        assertSameValue(['X-Transport' => 'safe'], $client->getResponseHeaders(), 'successful response headers were not stored');
+
+        $client->allowUnsafeUrls(true, ['internal.example']);
+        $response = $client->request('http://other.example/resource', 'GET', []);
+
+        assertInstanceOf(WP_Error::class, $response, 'non-allowlisted host was not rejected');
+        assertSameValue([], $client->getResponseHeaders(), 'authorization rejection retained stale response headers');
+    }
+
+    public function testHTTPClientResponseCodeIsEmptyAfterAuthorizationRejection(): void
+    {
+        $client = (new HttpClient())->allowUnsafeUrls(true, ['internal.example']);
+        $client->request('http://other.example/resource', 'GET', []);
+
+        assertSameValue('', $client->getResponseCode(), 'authorization rejection exposed a stale or malformed response code');
+    }
+
     public function testHTTPClientUnsafeRemoteRequestsPermitAnExactAllowlistedHost(): void
     {
         $client   = (new HttpClient())->allowUnsafeUrls(true, ['internal.example']);
@@ -222,6 +244,11 @@ final class HttpClientTest extends TestCase
             'multipart default was not applied',
         );
         assertSameValue(['internal.example'], $client->getAllowedUnsafeHosts(), 'unsafe host allowlist default was not applied');
+
+        $response = $client->request('http://internal.example/resource', 'GET', []);
+
+        assertSameValue(['safe' => 0, 'unsafe' => 1], WpKitTestState::$httpCalls, 'constructor did not enable unsafe transport');
+        assertSameValue(false, $response->safe, 'constructor-configured unsafe transport response was not returned');
     }
 
     public function testHTTPClientFluentConfigurationRetainsRequestValues(): void

--- a/tests/Http/HttpClientTest.php
+++ b/tests/Http/HttpClientTest.php
@@ -6,6 +6,7 @@ use BadMethodCallException;
 use BitApps\WPKit\Http\Client\HttpClient;
 use BitApps\WPKit\Tests\TestCase;
 use FakeWpError;
+use WP_Error;
 use WpKitTestState;
 
 /**
@@ -24,14 +25,128 @@ final class HttpClientTest extends TestCase
         assertSameValue(true, $response->safe, 'JSON response was not decoded');
     }
 
-    public function testHTTPClientUnsafeRemoteRequestsRequireExplicitOptIn(): void
+    public function testHTTPClientUnsafeRemoteRequestsFailClosedWithoutAnAllowlist(): void
     {
-        $client = new HttpClient();
-        $client->allowUnsafeUrls();
+        $client   = (new HttpClient())->allowUnsafeUrls();
         $response = $client->request('http://internal.example', 'GET', []);
 
-        assertSameValue(['safe' => 0, 'unsafe' => 1], WpKitTestState::$httpCalls, 'unsafe opt-in was ignored');
+        assertInstanceOf(WP_Error::class, $response, 'unsafe request without an allowlist was not rejected');
+        assertSameValue('unsafe_url_not_allowed', $response->get_error_code(), 'unexpected unsafe URL error code');
+        assertSameValue(['safe' => 0, 'unsafe' => 0], WpKitTestState::$httpCalls, 'rejected URL reached a transport');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsPermitAnExactAllowlistedHost(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['internal.example']);
+        $response = $client->request('http://internal.example/resource', 'GET', []);
+
+        assertSameValue(['safe' => 0, 'unsafe' => 1], WpKitTestState::$httpCalls, 'exact host did not use unsafe transport');
         assertSameValue(false, $response->safe, 'unsafe transport response was not returned');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsRejectADifferentHost(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['internal.example']);
+        $response = $client->request('http://other.example/resource', 'GET', []);
+
+        assertInstanceOf(WP_Error::class, $response, 'different host was not rejected');
+        assertSameValue('unsafe_url_not_allowed', $response->get_error_code(), 'unexpected unsafe URL error code');
+        assertSameValue(['safe' => 0, 'unsafe' => 0], WpKitTestState::$httpCalls, 'different host reached a transport');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsRejectSubdomainsOfAnAllowlistedHost(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['example.com']);
+        $response = $client->request('http://evil.example.com/resource', 'GET', []);
+
+        assertInstanceOf(WP_Error::class, $response, 'subdomain was not rejected');
+        assertSameValue('unsafe_url_not_allowed', $response->get_error_code(), 'unexpected unsafe URL error code');
+        assertSameValue(['safe' => 0, 'unsafe' => 0], WpKitTestState::$httpCalls, 'subdomain reached a transport');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsRejectHostsWithAnAllowlistedPrefix(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['example.com']);
+        $response = $client->request('http://example.com.evil.test/resource', 'GET', []);
+
+        assertInstanceOf(WP_Error::class, $response, 'host with allowlisted prefix was not rejected');
+        assertSameValue('unsafe_url_not_allowed', $response->get_error_code(), 'unexpected unsafe URL error code');
+        assertSameValue(['safe' => 0, 'unsafe' => 0], WpKitTestState::$httpCalls, 'prefixed host reached a transport');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsAuthorizeTheParsedHostNotUserInfo(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['example.com']);
+        $response = $client->request('http://user@example.com/resource', 'GET', []);
+
+        assertSameValue(['safe' => 0, 'unsafe' => 1], WpKitTestState::$httpCalls, 'URL user info changed host authorization');
+        assertSameValue(false, $response->safe, 'parsed host was not authorized');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsNormalizeTheParsedHost(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['EXAMPLE.COM']);
+        $response = $client->request('http://example.com./resource', 'GET', []);
+
+        assertSameValue(['safe' => 0, 'unsafe' => 1], WpKitTestState::$httpCalls, 'normalized host did not use unsafe transport');
+        assertSameValue(false, $response->safe, 'normalized host was not authorized');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsRejectUnsupportedSchemes(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['internal.example']);
+        $response = $client->request('ftp://internal.example/resource', 'GET', []);
+
+        assertInstanceOf(WP_Error::class, $response, 'unsupported scheme was not rejected');
+        assertSameValue('unsafe_url_not_allowed', $response->get_error_code(), 'unexpected unsafe URL error code');
+        assertSameValue(['safe' => 0, 'unsafe' => 0], WpKitTestState::$httpCalls, 'unsupported scheme reached a transport');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsRejectHostlessUrls(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['internal.example']);
+        $response = $client->request('/resource', 'GET', []);
+
+        assertInstanceOf(WP_Error::class, $response, 'hostless URL was not rejected');
+        assertSameValue('unsafe_url_not_allowed', $response->get_error_code(), 'unexpected unsafe URL error code');
+        assertSameValue(['safe' => 0, 'unsafe' => 0], WpKitTestState::$httpCalls, 'hostless URL reached a transport');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsRejectMalformedUrls(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['internal.example']);
+        $response = $client->request('http:///resource', 'GET', []);
+
+        assertInstanceOf(WP_Error::class, $response, 'malformed URL was not rejected');
+        assertSameValue('unsafe_url_not_allowed', $response->get_error_code(), 'unexpected unsafe URL error code');
+        assertSameValue(['safe' => 0, 'unsafe' => 0], WpKitTestState::$httpCalls, 'malformed URL reached a transport');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsPermitAnExactIpv6Host(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['2001:db8::1']);
+        $response = $client->request('http://[2001:db8::1]/resource', 'GET', []);
+
+        assertSameValue(['safe' => 0, 'unsafe' => 1], WpKitTestState::$httpCalls, 'exact IPv6 host did not use unsafe transport');
+        assertSameValue(false, $response->safe, 'IPv6 host was not authorized');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsAuthorizeHostsIndependentOfPort(): void
+    {
+        $client   = (new HttpClient())->allowUnsafeUrls(true, ['internal.example']);
+        $response = $client->request('https://internal.example:8443/resource', 'GET', []);
+
+        assertSameValue(['safe' => 0, 'unsafe' => 1], WpKitTestState::$httpCalls, 'URL port changed host authorization');
+        assertSameValue(false, $response->safe, 'host with a different port was not authorized');
+    }
+
+    public function testHTTPClientUnsafeRemoteRequestsDisableRedirects(): void
+    {
+        $client = (new HttpClient())->allowUnsafeUrls(true, ['internal.example']);
+        $client->request('http://internal.example/resource', 'GET', null, null, ['redirection' => 5]);
+
+        assertSameValue(['safe' => 0, 'unsafe' => 1], WpKitTestState::$httpCalls, 'allowlisted host did not use unsafe transport');
+        assertSameValue(0, WpKitTestState::$lastHttpRequest['options']['redirection'], 'unsafe transport retained redirects');
     }
 
     public function testHTTPClientUnsafeUrlAllowlistIsNormalizedAndReplaced(): void
@@ -40,7 +155,7 @@ final class HttpClientTest extends TestCase
 
         assertSameValue(
             $client,
-            $client->allowUnsafeUrls(true, ['  INTERNAL.example.  ', '[::1]', '127.0.0.1', 'internal.example']),
+            $client->allowUnsafeUrls(true, ['  INTERNAL.example.  ', '[::1]', '127.0.0.1']),
             'unsafe URL configuration stopped being fluent',
         );
         assertSameValue(
@@ -60,10 +175,18 @@ final class HttpClientTest extends TestCase
 
         assertSameValue(
             $client,
-            $client->setAllowedUnsafeHosts(['', ' https://internal.example ', 'host/path', '[bracketed.example]', [], true, 123, 'valid.example']),
+            $client->setAllowedUnsafeHosts(['', '   ', ' https://internal.example ', 'host/path', '[bracketed.example]', [], true, 123, 'valid.example']),
             'unsafe host allowlist setter stopped being fluent',
         );
         assertSameValue(['valid.example'], $client->getAllowedUnsafeHosts(), 'invalid unsafe host entries were retained');
+    }
+
+    public function testHTTPClientUnsafeHostAllowlistStoresNormalizedDuplicatesOnce(): void
+    {
+        $client = new HttpClient();
+        $client->setAllowedUnsafeHosts(['EXAMPLE.COM', 'example.com.', '  example.com  ']);
+
+        assertSameValue(['example.com'], $client->getAllowedUnsafeHosts(), 'normalized duplicate hosts were retained');
     }
 
     public function testHTTPClientWordPressErrorsAreReturnedUnchanged(): void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,6 +13,8 @@ if (!defined('ABSPATH')) {
     define('ABSPATH', __DIR__ . '/Fixtures/wordpress/');
 }
 
+require_once dirname(__DIR__) . '/src/Http/Client/HttpClient.php';
+
 final class WpKitTestState
 {
     public static $httpCalls = [];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -355,6 +355,10 @@ function wp_remote_retrieve_headers($response)
 
 function wp_remote_retrieve_response_code($response)
 {
+    if (is_wp_error($response) || !isset($response['response']) || !is_array($response['response'])) {
+        return '';
+    }
+
     return $response['response']['code'];
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -56,7 +56,25 @@ final class WpKitTestState
     public static $isAdmin = false;
 }
 
-final class FakeWpError
+class WP_Error
+{
+    private $code;
+
+    private $message;
+
+    public function __construct($code = '', $message = '')
+    {
+        $this->code    = $code;
+        $this->message = $message;
+    }
+
+    public function get_error_code()
+    {
+        return $this->code;
+    }
+}
+
+final class FakeWpError extends WP_Error
 {
 }
 
@@ -255,7 +273,7 @@ function assertThrows($exceptionClass, callable $callback, $message)
 
 function is_wp_error($value)
 {
-    return $value instanceof FakeWpError;
+    return $value instanceof WP_Error;
 }
 
 // mirrors WordPress core: flushes every buffer level to output, returns nothing
@@ -285,6 +303,11 @@ function wp_unslash($value)
 function wp_parse_args($args, $defaults = [])
 {
     return array_merge($defaults, (array) $args);
+}
+
+function wp_parse_url($url, $component = -1)
+{
+    return parse_url($url, $component);
 }
 
 function wp_json_encode($data, $options = 0, $depth = 512)


### PR DESCRIPTION
## Description

Hardens `HttpClient` unsafe mode with an explicit normalized host allowlist, exact parsed-host authorization, HTTP/HTTPS scheme checks, forced zero redirects, and fail-closed errors before any transport call. Safe mode remains on WordPress safe transport.

## Motivation & Context

The previous boolean opt-in allowed unrestricted use of `wp_remote_request`, which could expose private-network endpoints when request URLs were influenced by untrusted input. Unsafe transport now requires administrator-configured exact hosts and cannot follow redirects.

## Type of Change

- [x] Security bug fix
- [x] Backward-compatible API extension
- [x] Intentional fail-closed behavior change
- [x] Tests and documentation

## Security Behavior

- `allowUnsafeUrls(true)` without hosts now returns `WP_Error` with `unsafe_url_not_allowed`.
- Allowed hosts use exact normalized comparison; subdomains and suffix/prefix lookalikes are rejected.
- Only `http` and `https` URLs are eligible.
- Caller options cannot re-enable redirects in unsafe mode.
- Rejected requests make zero HTTP transport calls and clear prior response state.
- Authorization is host-only; untrusted ports, paths, queries, and other URL components still require separate validation.

## Verification

- 165 tests, 352 assertions
- PHPCompatibility: 39/39 source files
- Focused SSRF/parser, response-state, constructor, and error-accessor regressions pass
- CS Fixer dry run, PHP syntax, and `git diff --check` pass
- Independent task reviews and final whole-branch security review approved
- `src/Http/IpTool.php` remains untouched

## Checklist

- [x] Code follows project style and PHP 8 compatibility requirements
- [x] Self-review and independent security review completed
- [x] Tests added and updated
- [x] Migration documentation updated
- [x] Setup-only `vendor` symlink excluded from the PR